### PR TITLE
linux: change nvme_link_get_name to return base name

### DIFF
--- a/src/nvme/linux.c
+++ b/src/nvme/linux.c
@@ -181,7 +181,7 @@ bool nvme_link_is_mi(nvme_link_t l)
 
 const char *nvme_link_get_name(nvme_link_t l)
 {
-	return l->name;
+	return basename(l->name);
 }
 
 int nvme_fw_download_seq(nvme_link_t l, __u32 size, __u32 xfer, __u32 offset,


### PR DESCRIPTION
Since the almost nvme-cli caller functions expected the base name.