### PR TITLE
ioctl: rework nvme_dsm command

### DIFF
--- a/src/libnvme.map
+++ b/src/libnvme.map
@@ -67,7 +67,6 @@ LIBNVME_2_0 {
 		nvme_directive_send;
 		nvme_directive_send_id_endir;
 		nvme_disconnect_ctrl;
-		nvme_dsm;
 		nvme_dump_config;
 		nvme_dump_tree;
 		nvme_errno_to_string;

--- a/src/nvme/api-types.h
+++ b/src/nvme/api-types.h
@@ -548,26 +548,6 @@ struct nvme_io_args {
 };
 
 /**
- * struct nvme_dsm_args - Arguments for the NVMe Dataset Management command
- * @result:	The command completion result from CQE dword0
- * @dsm:	The data set management attributes
- * @args_size:	Size of &struct nvme_dsm_args
- * @timeout:	Timeout in ms
- * @nsid:	Namespace identifier
- * @attrs:	DSM attributes, see &enum nvme_dsm_attributes
- * @nr_ranges:	Number of block ranges in the data set management attributes
- */
-struct nvme_dsm_args {
-	__u32 *result;
-	struct nvme_dsm_range *dsm;
-	int args_size;
-	__u32 timeout;
-	__u32 nsid;
-	__u32 attrs;
-	__u16 nr_ranges;
-};
-
-/**
  * struct nvme_copy_args - Arguments for the NVMe Copy command
  * @sdlba:	Start destination LBA
  * @result:	The command completion result from CQE dword0

--- a/src/nvme/ioctl.c
+++ b/src/nvme/ioctl.c
@@ -1848,24 +1848,6 @@ int nvme_io(struct nvme_transport_handle *hdl, struct nvme_io_args *args, __u8 o
 	return nvme_submit_io_passthru(hdl, &cmd, args->result);
 }
 
-int nvme_dsm(struct nvme_transport_handle *hdl, struct nvme_dsm_args *args)
-{
-	struct nvme_passthru_cmd cmd = {
-		.opcode		= nvme_cmd_dsm,
-		.nsid		= args->nsid,
-		.addr		= (__u64)(uintptr_t)args->dsm,
-		.data_len	= args->nr_ranges * sizeof(*args->dsm),
-		.cdw10		= args->nr_ranges - 1,
-		.cdw11		= args->attrs,
-		.timeout_ms	= args->timeout,
-	};
-
-	if (args->args_size < sizeof(*args))
-		return -EINVAL;
-
-	return nvme_submit_io_passthru(hdl, &cmd, args->result);
-}
-
 int nvme_copy(struct nvme_transport_handle *hdl, struct nvme_copy_args *args)
 {
 	__u32 cdw3, cdw12, cdw14, data_len;

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -320,6 +320,14 @@ enum nvme_cmd_dword_fields {
 	NVME_ZNS_MGMT_RECV_ZRAS_FEAT_MASK			= 0x1,
 	NVME_DIM_TAS_SHIFT					= 0,
 	NVME_DIM_TAS_MASK					= 0xF,
+	NVME_DSM_CDW10_NR_SHIFT					= 0,
+	NVME_DSM_CDW10_NR_MASK					= 0xff,
+	NVME_DSM_CDW11_IDR_SHIFT				= 0,
+	NVME_DSM_CDW11_IDR_MASK					= 0x1,
+	NVME_DSM_CDW11_IDW_SHIFT				= 1,
+	NVME_DSM_CDW11_IDW_MASK					= 0x1,
+	NVME_DSM_CDW11_AD_SHIFT					= 2,
+	NVME_DSM_CDW11_AD_MASK					= 0x1,
 };
 
 #define NVME_FIELD_ENCODE(value, shift, mask) \
@@ -3717,20 +3725,44 @@ static inline int nvme_verify(struct nvme_transport_handle *hdl, struct nvme_io_
 }
 
 /**
- * nvme_dsm() - Send an nvme data set management command
- * @hdl:	Transport handle
- * @args:	&struct nvme_dsm_args argument structure
- *
- * The Dataset Management command is used by the host to indicate attributes
- * for ranges of logical blocks. This includes attributes like frequency that
- * data is read or written, access size, and other information that may be used
- * to optimize performance and reliability, and may be used to
- * deallocate/unmap/trim those logical blocks.
- *
- * Return: 0 on success, the nvme command status if a response was
- * received (see &enum nvme_status_field) or a negative error otherwise.
+ * nvme_init_dsm() - Initialize passthru command for
+ * NVMEe I/O Data Set Management
+ * @cmd:	Passthru command to use
+ * @nsid:	Namespace identifier
+ * @nr:		Number of block ranges in the data set management attributes
+ * @idr:	DSM Deallocate attribute
+ * @idw:	DSM Integral Dataset for Read attribute
+ * @ad:		DSM Integral Dataset for Read attribute
+ * @data:	User space destination address to transfer the data
+ * @len:	Length of provided user buffer to hold the log data in bytes
  */
-int nvme_dsm(struct nvme_transport_handle *hdl, struct nvme_dsm_args *args);
+static inline void
+nvme_init_dsm(struct nvme_passthru_cmd *cmd,
+		__u32 nsid, __u16 nr, __u8 idr, __u8 idw, __u8 ad, void *data,
+		__u32 len)
+{
+	__u32 cdw10 = NVME_FIELD_ENCODE(nr,
+					NVME_DSM_CDW10_NR_SHIFT,
+					NVME_DSM_CDW10_NR_MASK);
+	__u32 cdw11 = NVME_FIELD_ENCODE(idr,
+					NVME_DSM_CDW11_IDR_SHIFT,
+					NVME_DSM_CDW11_IDR_MASK) |
+		      NVME_FIELD_ENCODE(idw,
+					NVME_DSM_CDW11_IDW_SHIFT,
+					NVME_DSM_CDW11_IDW_MASK) |
+		      NVME_FIELD_ENCODE(ad,
+					NVME_DSM_CDW11_AD_SHIFT,
+					NVME_DSM_CDW11_AD_MASK);
+
+	memset(cmd, 0, sizeof(*cmd));
+
+	cmd->opcode	= nvme_cmd_dsm;
+	cmd->nsid	= nsid;
+	cmd->cdw10	= cdw10;
+	cmd->cdw11	= cdw11;
+	cmd->data_len	= len;
+	cmd->addr	= (__u64)(uintptr_t)data;
+}
 
 /**
  * nvme_copy() - Copy command


### PR DESCRIPTION
Replace the struct args approach by providing init function for initializing the passthru commands. This reduces the dependency between callside and library.