### PR TITLE
ioctl: fix nvme_init_app_tag() cmd parameter to 32-bit version

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -4434,7 +4434,7 @@ nvme_init_dsm(struct nvme_passthru_cmd *cmd,
  * the command-specific init function (like nvme_init_zns_append).
  */
 static inline int
-nvme_init_var_size_tags(struct nvme_passthru_cmd64 *cmd,
+nvme_init_var_size_tags(struct nvme_passthru_cmd *cmd,
 		__u8 pif, __u8 sts, __u64 reftag, __u64 storage_tag)
 {
 	__u32 cdw2 = 0, cdw3 = 0, cdw14 = 0;
@@ -4508,7 +4508,7 @@ nvme_init_var_size_tags(struct nvme_passthru_cmd64 *cmd,
  * @lbatm:	Logical block application tag mask
  */
 static inline void
-nvme_init_app_tag(struct nvme_passthru_cmd64 *cmd,
+nvme_init_app_tag(struct nvme_passthru_cmd *cmd,
 	__u16 lbat, __u16 lbatm)
 {
 	cmd->cdw15 = NVME_FIELD_ENCODE(lbat,
@@ -5251,7 +5251,7 @@ nvme_init_zns_report_zones(struct nvme_passthru_cmd *cmd, __u32 nsid,
  * Initializes the passthru command buffer for the ZNS Append command.
  */
 static inline void
-nvme_init_zns_append(struct nvme_passthru_cmd64 *cmd, __u32 nsid,
+nvme_init_zns_append(struct nvme_passthru_cmd *cmd, __u32 nsid,
 		__u64 zslba, __u16 nlb, __u16 control, __u16 cev, __u16 dspec,
 		void *data, __u32 data_len, void *metadata, __u32 metadata_len)
 {

--- a/test/ioctl/misc.c
+++ b/test/ioctl/misc.c
@@ -791,7 +791,7 @@ static void test_read(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_read(&cmd, TEST_NSID, slba, nlb, control, dsm, 0,
 		data, sizeof(data), NULL, 0);
-	nvme_init_app_tag((struct nvme_passthru_cmd64 *)&cmd, apptag, appmask);
+	nvme_init_app_tag(&cmd, apptag, appmask);
 	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
@@ -827,7 +827,7 @@ static void test_write(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_write(&cmd, TEST_NSID, slba, nlb, control, dspec, dsm, 0,
 		expected_data, sizeof(expected_data), NULL, 0);
-	nvme_init_app_tag((struct nvme_passthru_cmd64 *)&cmd, apptag, appmask);
+	nvme_init_app_tag(&cmd, apptag, appmask);
 	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
@@ -862,7 +862,7 @@ static void test_compare(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_compare(&cmd, TEST_NSID, slba, nlb, control, cev, data,
 		sizeof(data), NULL, 0);
-	nvme_init_app_tag((struct nvme_passthru_cmd64 *)&cmd, apptag, appmask);
+	nvme_init_app_tag(&cmd, apptag, appmask);
 	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
@@ -895,7 +895,7 @@ static void test_write_zeros(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_write_zeros(&cmd, TEST_NSID, slba, nlb, control,
 		dspec, dsm, cev);
-	nvme_init_app_tag((struct nvme_passthru_cmd64 *)&cmd, apptag, appmask);
+	nvme_init_app_tag(&cmd, apptag, appmask);
 	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
@@ -927,7 +927,7 @@ static void test_write_uncorrectable(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_write_uncorrectable(&cmd, TEST_NSID, slba, nlb,
 		control, dspec);
-	nvme_init_app_tag((struct nvme_passthru_cmd64 *)&cmd, apptag, appmask);
+	nvme_init_app_tag(&cmd, apptag, appmask);
 	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
@@ -958,7 +958,7 @@ static void test_verify(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_verify(&cmd, TEST_NSID, slba, nlb, control, cev,
 		NULL, 0, NULL, 0);
-	nvme_init_app_tag((struct nvme_passthru_cmd64 *)&cmd, apptag, appmask);
+	nvme_init_app_tag(&cmd, apptag, appmask);
 	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);

--- a/test/ioctl/zns.c
+++ b/test/ioctl/zns.c
@@ -24,7 +24,7 @@ static void test_zns_append(void)
 	__u16 lbatm = 0x98;
 	__u16 lbat = 0xef;
 	__u16 nlb = 0xab;
-	__u64 result = 0;
+	__u32 result = 0;
 	bool elbas = true;
 	__u8 sts = 48;
 	__u8 pif = NVME_NVM_PIF_32B_GUARD;
@@ -42,7 +42,7 @@ static void test_zns_append(void)
 		.data_len = sizeof(expected_data),
 		.out_data = &expected_data,
 	};
-	struct nvme_passthru_cmd64 cmd;
+	struct nvme_passthru_cmd cmd;
 	int err;
 
 	arbitrary(&expected_data, sizeof(expected_data));
@@ -52,7 +52,7 @@ static void test_zns_append(void)
 	if (elbas)
 		nvme_init_var_size_tags(&cmd, pif, sts, reftag, storage_tag);
 	nvme_init_app_tag(&cmd, lbat, lbatm);
-	err = nvme_submit_io_passthru64(test_hdl, &cmd, &result);
+	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(result == 0, "wrong result");


### PR DESCRIPTION
This is to resolve the build warnings below.

In function ‘nvme_init_app_tag’,
    inlined from ‘test_verify’ at ../test/ioctl/misc.c:961:2:
../src/nvme/ioctl.h:4514:20: warning: array subscript ‘struct nvme_passthru_cmd64[0]’ is partly outside array bounds of ‘struct nvme_passthru_cmd[1]’ [-Warray-bounds=]
 4514 |         cmd->cdw15 = NVME_FIELD_ENCODE(lbat,
      |                    ^
../test/ioctl/misc.c: In function ‘test_verify’:
../test/ioctl/misc.c:955:34: note: object ‘cmd’ of size 72
  955 |         struct nvme_passthru_cmd cmd;
      |                                  ^~~
In function ‘nvme_init_app_tag’,
    inlined from ‘test_compare’ at ../test/ioctl/misc.c:865:2:
../src/nvme/ioctl.h:4514:20: warning: array subscript ‘struct nvme_passthru_cmd64[0]’ is partly outside array bounds of ‘struct nvme_passthru_cmd[1]’ [-Warray-bounds=]
 4514 |         cmd->cdw15 = NVME_FIELD_ENCODE(lbat,
      |                    ^
../test/ioctl/misc.c: In function ‘test_compare’:
../test/ioctl/misc.c:857:34: note: object ‘cmd’ of size 72
  857 |         struct nvme_passthru_cmd cmd;
      |                                  ^~~
In function ‘nvme_init_app_tag’,
    inlined from ‘test_write’ at ../test/ioctl/misc.c:830:2:
../src/nvme/ioctl.h:4514:20: warning: array subscript ‘struct nvme_passthru_cmd64[0]’ is partly outside array bounds of ‘struct nvme_passthru_cmd[1]’ [-Warray-bounds=]
 4514 |         cmd->cdw15 = NVME_FIELD_ENCODE(lbat,
      |                    ^
../test/ioctl/misc.c: In function ‘test_write’:
../test/ioctl/misc.c:823:34: note: object ‘cmd’ of size 72
  823 |         struct nvme_passthru_cmd cmd;
      |                                  ^~~
In function ‘nvme_init_app_tag’,
    inlined from ‘test_read’ at ../test/ioctl/misc.c:794:2:
../src/nvme/ioctl.h:4514:20: warning: array subscript ‘struct nvme_passthru_cmd64[0]’ is partly outside array bounds of ‘struct nvme_passthru_cmd[1]’ [-Warray-bounds=]
 4514 |         cmd->cdw15 = NVME_FIELD_ENCODE(lbat,
      |                    ^
../test/ioctl/misc.c: In function ‘test_read’:
../test/ioctl/misc.c:787:34: note: object ‘cmd’ of size 72
  787 |         struct nvme_passthru_cmd cmd;
      |                                  ^~~
In function ‘nvme_init_app_tag’,
    inlined from ‘test_write_zeros’ at ../test/ioctl/misc.c:898:2:
../src/nvme/ioctl.h:4514:20: warning: array subscript ‘struct nvme_passthru_cmd64[0]’ is partly outside array bounds of ‘struct nvme_passthru_cmd[1]’ [-Warray-bounds=]
 4514 |         cmd->cdw15 = NVME_FIELD_ENCODE(lbat,
      |                    ^
../test/ioctl/misc.c: In function ‘test_write_zeros’:
../test/ioctl/misc.c:892:34: note: object ‘cmd’ of size 72
  892 |         struct nvme_passthru_cmd cmd;
      |                                  ^~~