### PR TITLE
ioctl: introduce nvme_identify helper functions

### DIFF
--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -5693,4 +5693,89 @@ nvme_zns_identify_ns(struct nvme_transport_handle *hdl,
 
 	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
 }
+
+static inline int
+nvme_get_csi_log(struct nvme_transport_handle *hdl, __u32 nsid,
+		enum nvme_cmd_get_log_lid lid, bool rae, enum nvme_csi csi,
+		void *data, __u32 len)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_get_log(&cmd, nsid, lid, csi, data, len);
+
+	return nvme_get_log(hdl, &cmd, rae, NVME_LOG_PAGE_PDU_SIZE, NULL);
+}
+
+static inline int
+nvme_get_nsid_log(struct nvme_transport_handle *hdl, __u32 nsid,
+		enum nvme_cmd_get_log_lid lid, bool rae, void *data, __u32 len)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_get_log(&cmd, nsid, lid, NVME_CSI_NVM, data, len);
+
+	return nvme_get_log(hdl, &cmd, rae, NVME_LOG_PAGE_PDU_SIZE, NULL);
+}
+
+static inline int
+nvme_get_log_simple(struct nvme_transport_handle *hdl,
+		enum nvme_cmd_get_log_lid lid, void *data, __u32 len)
+{
+	return nvme_get_nsid_log(hdl, NVME_NSID_ALL, lid, false, data, len);
+}
+
+static inline int
+nvme_get_log_smart(struct nvme_transport_handle *hdl,
+		__u32 nsid, bool rae, struct nvme_smart_log *smart_log)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_get_log_smart(&cmd, nsid, smart_log);
+
+	return nvme_get_log(hdl, &cmd, rae, NVME_LOG_PAGE_PDU_SIZE, NULL);
+}
+
+static inline int
+nvme_set_features(struct nvme_transport_handle *hdl, __u32 nsid, __u8 fid,
+		bool sv, __u32 cdw11, __u32 cdw12, __u32 cdw13, __u8 uidx,
+		__u32 cdw15, void *data, __u32 len, __u32 *result)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_set_features(&cmd, fid, sv);
+	cmd.nsid = nsid;
+	cmd.cdw11 = cdw11;
+	cmd.cdw12 = cdw12;
+	cmd.cdw13 = cdw13;
+	cmd.cdw14 = NVME_FIELD_ENCODE(uidx,
+				      NVME_IDENTIFY_CDW14_UUID_SHIFT,
+				      NVME_IDENTIFY_CDW14_UUID_MASK);
+	cmd.cdw15 = cdw15;
+
+	return nvme_submit_admin_passthru(hdl, &cmd, result);
+}
+
+static inline int
+nvme_set_features_simple(struct nvme_transport_handle *hdl,
+		__u32 nsid, __u8 fid, bool sv, __u32 cdw11, __u32 *result)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_set_features(&cmd, fid, sv);
+	cmd.nsid = nsid;
+	cmd.cdw11 = cdw11;
+
+	return nvme_submit_admin_passthru(hdl, &cmd, result);
+}
+
+static inline int
+nvme_get_features(struct nvme_transport_handle *hdl, __u8 fid,
+		enum nvme_get_features_sel sel, __u32 *result)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_get_features(&cmd, fid, sel);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, result);
+}
 #endif /* _LIBNVME_IOCTL_H */

--- a/src/nvme/ioctl.h
+++ b/src/nvme/ioctl.h
@@ -5583,4 +5583,114 @@ nvme_init_lm_get_features_ctrl_data_queue(struct nvme_passthru_cmd *cmd,
 	cmd->addr = (__u64)(uintptr_t)qfd;
 	cmd->cdw11 = cdqid;
 }
+
+static inline int
+nvme_identify_ctrl(struct nvme_transport_handle *hdl,
+		struct nvme_id_ctrl *id)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_ctrl(&cmd, id);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify_active_ns_list(struct nvme_transport_handle *hdl,
+		__u32 nsid, struct nvme_ns_list *ns_list)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_active_ns_list(&cmd, nsid, ns_list);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify_ns(struct nvme_transport_handle *hdl,
+		__u32 nsid, struct nvme_id_ns *ns)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_ns(&cmd, nsid, ns);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify_csi_ns(struct nvme_transport_handle *hdl, __u32 nsid,
+		enum nvme_csi csi, __u8 uidx, struct nvme_nvm_id_ns *id_ns)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_csi_ns(&cmd, nsid, csi, uidx, id_ns);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify_uuid_list(struct nvme_transport_handle *hdl,
+		struct nvme_id_uuid_list *uuid_list)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_uuid_list(&cmd, uuid_list);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify(struct nvme_transport_handle *hdl, __u32 nsid, enum nvme_csi csi,
+		enum nvme_identify_cns cns, void *data, __u32 len)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify(&cmd, nsid, csi, cns, data, len);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify_csi_ns_user_data_format(struct nvme_transport_handle *hdl,
+		enum nvme_csi csi, __u16 fidx, __u8 uidx, void *data)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_csi_ns_user_data_format(&cmd, csi, fidx, uidx, data);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify_ns_granularity(struct nvme_transport_handle *hdl,
+		struct nvme_id_ns_granularity_list *gr_list)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_ns_granularity(&cmd, gr_list);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_identify_ns_descs_list(struct nvme_transport_handle *hdl,
+		__u32 nsid, struct nvme_ns_id_desc *descs)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_identify_ns_descs_list(&cmd, nsid, descs);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
+
+static inline int
+nvme_zns_identify_ns(struct nvme_transport_handle *hdl,
+		__u32 nsid, struct nvme_zns_id_ns *data)
+{
+	struct nvme_passthru_cmd cmd;
+
+	nvme_init_zns_identify_ns(&cmd, nsid, data);
+
+	return nvme_submit_admin_passthru(hdl, &cmd, NULL);
+}
 #endif /* _LIBNVME_IOCTL_H */


### PR DESCRIPTION
Reduce nvme_init_identify_ctrl and nvme_submit_admin_passthru calls.